### PR TITLE
Implement 3D hero and update hero section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,8 @@
 
 import { Header } from '@/components/layout/header';
 import { Footer } from '@/components/layout/footer';
-import { HeroSection } from '@/components/sections/hero-section';
+import { HeroSection } from '@/components/sections/hero-section'
+import { personalInfo } from '@/data/portfolio-data'
 import { AboutPreviewSection } from '@/components/sections/about-preview-section';
 import { ExperiencePreviewSection } from '@/components/sections/experience-preview-section';
 import { FeaturedProjectsSection } from '@/components/sections/featured-projects-section';
@@ -14,7 +15,7 @@ export default function HomePage() {
   return (
     <div className="min-h-screen">
       <Header />
-      <HeroSection />
+      <HeroSection personalInfo={personalInfo} />
       <AboutPreviewSection />
       <ExperiencePreviewSection />
       <FeaturedProjectsSection />

--- a/components/sections/hero-section.tsx
+++ b/components/sections/hero-section.tsx
@@ -6,13 +6,17 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { useEffect, useState } from 'react';
 import { ArrowRight, Github, Linkedin, Mail, ChevronDown } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { personalInfo } from '@/data/portfolio-data';
+import { Button } from '@/components/ui/button'
+import type { PersonalInfo } from '@/data/portfolio-data'
 
 // Dynamically import the 3D scene so it's only loaded when needed
-const Hero3D = dynamic(() => import('../ui/hero-3d'), { ssr: false });
+const Hero3D = dynamic(() => import('../ui/hero-3d'), { ssr: false })
 
-export function HeroSection() {
+export interface HeroSectionProps {
+  personalInfo: PersonalInfo
+}
+
+export function HeroSection({ personalInfo }: HeroSectionProps) {
   const shouldReduceMotion = useReducedMotion();
   const [show3D, setShow3D] = useState(false);
 
@@ -29,7 +33,7 @@ export function HeroSection() {
       {!show3D && (
         <div className="absolute inset-0 bg-gradient-to-br from-background via-background to-muted/20" />
       )}
-      {show3D && <Hero3D />}
+      {show3D && <Hero3D autoRotate />}
       <div className="container relative z-10">
         <motion.div
           initial={{ opacity: 0, y: 30 }}
@@ -43,7 +47,10 @@ export function HeroSection() {
               {personalInfo.name}
             </span>
           </h1>
-          <p className="text-xl md:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto">
+          <p className="text-xl md:text-2xl text-muted-foreground mb-4 max-w-3xl mx-auto">
+            {personalInfo.title} based in {personalInfo.location}
+          </p>
+          <p className="text-lg md:text-xl text-muted-foreground mb-8 max-w-3xl mx-auto">
             {personalInfo.description}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
@@ -55,6 +62,9 @@ export function HeroSection() {
             </Button>
             <Button variant="outline" size="lg" asChild>
               <Link href="/projects">View Portfolio</Link>
+            </Button>
+            <Button variant="secondary" size="lg" asChild>
+              <Link href={personalInfo.social.email}>Email Me</Link>
             </Button>
           </div>
           <div className="flex justify-center space-x-4">

--- a/components/ui/hero-3d.tsx
+++ b/components/ui/hero-3d.tsx
@@ -1,14 +1,96 @@
-'use client';
+"use client"
+
+import { useEffect, useRef } from "react"
+import * as THREE from "three"
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls"
+
+export interface Hero3DProps {
+  /** Rotate the camera automatically using OrbitControls */
+  autoRotate?: boolean
+}
 
 /**
- * Placeholder for a heavy 3D scene. In the real project this would render
- * the WebGL or Three.js content for the hero section.
+ * Renders a lightweight Three.js scene with floating geometry and particles.
+ * The component uses imperative Three.js APIs so it can live alongside other
+ * React UI without additional dependencies like react-three-fiber.
  */
-export default function Hero3D() {
-  return (
-    <div className="absolute inset-0">
-      {/* 3D scene goes here */}
-    </div>
-  );
+export function Hero3D({ autoRotate = true }: Hero3DProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    // Scene setup
+    const scene = new THREE.Scene()
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      container.clientWidth / container.clientHeight,
+      0.1,
+      1000
+    )
+    camera.position.z = 5
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+    renderer.setPixelRatio(window.devicePixelRatio)
+    renderer.setSize(container.clientWidth, container.clientHeight)
+    container.appendChild(renderer.domElement)
+
+    // Floating geometry
+    const geometry = new THREE.IcosahedronGeometry(1, 0)
+    const material = new THREE.MeshNormalMaterial()
+    const mesh = new THREE.Mesh(geometry, material)
+    scene.add(mesh)
+
+    // Simple particle system
+    const particlesCount = 200
+    const positions = new Float32Array(particlesCount * 3)
+    for (let i = 0; i < particlesCount * 3; i++) {
+      positions[i] = (Math.random() - 0.5) * 10
+    }
+    const particleGeometry = new THREE.BufferGeometry()
+    particleGeometry.setAttribute(
+      "position",
+      new THREE.BufferAttribute(positions, 3)
+    )
+    const particleMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 0.02 })
+    const particles = new THREE.Points(particleGeometry, particleMaterial)
+    scene.add(particles)
+
+    // Camera controls
+    const controls = new OrbitControls(camera, renderer.domElement)
+    controls.autoRotate = autoRotate
+    controls.enableDamping = true
+
+    const onResize = () => {
+      const { clientWidth, clientHeight } = container
+      renderer.setSize(clientWidth, clientHeight)
+      camera.aspect = clientWidth / clientHeight
+      camera.updateProjectionMatrix()
+    }
+    window.addEventListener("resize", onResize)
+
+    let frameId: number
+    const animate = () => {
+      mesh.rotation.x += 0.005
+      mesh.rotation.y += 0.01
+      controls.update()
+      renderer.render(scene, camera)
+      frameId = requestAnimationFrame(animate)
+    }
+    animate()
+
+    return () => {
+      cancelAnimationFrame(frameId)
+      window.removeEventListener("resize", onResize)
+      controls.dispose()
+      renderer.dispose()
+      container.removeChild(renderer.domElement)
+    }
+  }, [autoRotate])
+
+  return <div ref={containerRef} className="absolute inset-0" />
 }
+
+export default Hero3D
 

--- a/data/portfolio-data.ts
+++ b/data/portfolio-data.ts
@@ -32,6 +32,19 @@ export interface Skill {
   icon?: string;
 }
 
+export interface PersonalInfo {
+  name: string
+  title: string
+  email: string
+  location: string
+  description: string
+  social: {
+    github: string
+    linkedin: string
+    email: string
+  }
+}
+
 export const personalInfo = {
   name: "Ratan Bunkar",
   title: "Systems Integration Engineer",


### PR DESCRIPTION
## Summary
- add Three.js powered `Hero3D` component
- enhance `HeroSection` layout and accept `personalInfo` prop
- type portfolio personal information and export
- pass data from `page.tsx` to `HeroSection`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd23dcee08322ae1d869e9d25e096