### PR TITLE
Enable contact form backend integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ pnpm dev
 - **Skills** - Technologies you work with
 - **Contact** - Get in touch section
 
+### Contact Form
+Set the `CONTACT_FORM_ENDPOINT` environment variable to the URL of your backend
+or email service that will process form submissions. The app sends a POST
+request with JSON `{ name, email, subject, message }` to this endpoint.
+
 ## 🚀 Deployment
 
 ### Vercel (Recommended)

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  try {
+    const data = await req.json();
+    const endpoint = process.env.CONTACT_FORM_ENDPOINT;
+    if (!endpoint) {
+      console.error('CONTACT_FORM_ENDPOINT is not set');
+      return NextResponse.json({ error: 'Service unavailable' }, { status: 500 });
+    }
+
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
+    });
+
+    if (!res.ok) {
+      throw new Error('Request failed');
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Contact form error:', error);
+    return NextResponse.json({ error: 'Failed to send message' }, { status: 500 });
+  }
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -53,10 +53,28 @@ export default function ContactPage() {
     message: ''
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Handle form submission here
-    console.log('Form submitted:', formData);
+    setStatus('loading');
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(formData)
+      });
+      if (!res.ok) {
+        throw new Error('Failed to send message');
+      }
+      setStatus('success');
+      setFormData({ name: '', email: '', subject: '', message: '' });
+    } catch (error) {
+      console.error('Error sending message', error);
+      setStatus('error');
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -217,6 +235,15 @@ export default function ContactPage() {
                       <Send className="mr-2 h-4 w-4" />
                       Send Message
                     </Button>
+                    {status === 'success' && (
+                      <p className="text-sm text-green-600 text-center">Message sent successfully.</p>
+                    )}
+                    {status === 'error' && (
+                      <p className="text-sm text-red-600 text-center">Failed to send message. Please try again.</p>
+                    )}
+                    {status === 'loading' && (
+                      <p className="text-sm text-muted-foreground text-center">Sending...</p>
+                    )}
                   </form>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary
- connect contact page form to `/api/contact`
- implement API route that forwards submissions to an external service via `CONTACT_FORM_ENDPOINT`
- document `CONTACT_FORM_ENDPOINT` env variable

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684915dd64f483229a857c39b0ac1e98