### PR TITLE
Add dynamic blog posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from 'next/navigation';
+import { blogPosts } from '@/data/blog-posts';
+import { Header } from '@/components/layout/header';
+import { Footer } from '@/components/layout/footer';
+
+interface Params {
+  params: { slug: string };
+}
+
+export default function BlogPostPage({ params }: Params) {
+  const post = blogPosts.find((p) => p.slug === params.slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <section className="py-20 px-4">
+        <div className="container max-w-3xl">
+          <h1 className="text-4xl font-bold mb-4">{post.title}</h1>
+          <p className="text-muted-foreground mb-8">{post.excerpt}</p>
+          <p>Blog post content coming soon.</p>
+        </div>
+      </section>
+      <Footer />
+    </div>
+  );
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,12 +3,9 @@ import { blogPosts } from '@/data/blog-posts';
 import { Header } from '@/components/layout/header';
 import { Footer } from '@/components/layout/footer';
 
-interface Params {
-  params: { slug: string };
-}
-
-export default function BlogPostPage({ params }: Params) {
-  const post = blogPosts.find((p) => p.slug === params.slug);
+export default async function BlogPostPage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const post = blogPosts.find((p) => p.slug === slug);
 
   if (!post) {
     notFound();

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,43 +1,14 @@
 'use client';
 
 import { motion } from 'framer-motion';
-import { Calendar, Clock, ArrowRight } from 'lucide-react';
+import { Calendar, Clock } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Header } from '@/components/layout/header';
 import { Footer } from '@/components/layout/footer';
+import { blogPosts } from '@/data/blog-posts';
 
-// Mock blog posts data
-const blogPosts = [
-  {
-    id: 1,
-    title: "Best Practices for Medical Device Test Automation",
-    excerpt: "Exploring effective strategies for implementing automated testing in medical device development while maintaining regulatory compliance.",
-    date: "2024-01-15",
-    readTime: "8 min read",
-    category: "Automation",
-    tags: ["Medical Devices", "Test Automation", "ISO 13485"]
-  },
-  {
-    id: 2,
-    title: "Requirements Engineering in Complex Systems",
-    excerpt: "A deep dive into how proper requirements engineering can make or break complex system implementations.",
-    date: "2024-01-08",
-    readTime: "6 min read",
-    category: "Systems Engineering",
-    tags: ["Requirements", "Systems", "Engineering"]
-  },
-  {
-    id: 3,
-    title: "Python for Engineering Automation",
-    excerpt: "How Python has transformed our approach to engineering automation and the tools that make it possible.",
-    date: "2024-01-01",
-    readTime: "10 min read",
-    category: "Programming",
-    tags: ["Python", "Automation", "Engineering"]
-  }
-];
 
 export default function BlogPage() {
   return (
@@ -67,47 +38,6 @@ export default function BlogPage() {
         </div>
       </section>
 
-      {/* Coming Soon Message */}
-      <section className="py-12 px-4 bg-muted/30">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-            viewport={{ once: true }}
-            className="text-center mb-12"
-          >
-            <Card className="max-w-2xl mx-auto">
-              <CardHeader>
-                <CardTitle className="text-2xl">Blog Coming Soon!</CardTitle>
-                <CardDescription>
-                  I'm currently working on setting up my blog where I'll share insights 
-                  about systems engineering, medical device development, and automation.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <p className="text-muted-foreground mb-6">
-                  In the meantime, feel free to connect with me on LinkedIn or check out 
-                  my projects to see what I'm working on.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                  <Button asChild>
-                    <a href="https://linkedin.com/in/ratanbunkar" target="_blank" rel="noopener noreferrer">
-                      Connect on LinkedIn
-                    </a>
-                  </Button>
-                  <Button variant="outline" asChild>
-                    <a href="/projects">
-                      View My Projects
-                      <ArrowRight className="ml-2 h-4 w-4" />
-                    </a>
-                  </Button>
-                </div>
-              </CardContent>
-            </Card>
-          </motion.div>
-        </div>
-      </section>
 
       {/* Planned Content Preview */}
       <section className="py-20 px-4">
@@ -119,9 +49,9 @@ export default function BlogPage() {
             viewport={{ once: true }}
             className="text-center mb-16"
           >
-            <h2 className="text-3xl md:text-4xl font-bold mb-4">What to Expect</h2>
+            <h2 className="text-3xl md:text-4xl font-bold mb-4">Latest Posts</h2>
             <p className="text-lg text-muted-foreground">
-              Topics I'll be covering in upcoming blog posts
+              Articles and insights from my work in systems engineering and automation
             </p>
           </motion.div>
 
@@ -158,8 +88,8 @@ export default function BlogPage() {
                       ))}
                     </div>
                     
-                    <Button variant="ghost" size="sm" disabled className="w-full">
-                      Coming Soon
+                    <Button variant="ghost" size="sm" asChild className="w-full">
+                      <a href={`/blog/${post.slug}`}>Read More</a>
                     </Button>
                   </CardContent>
                 </Card>

--- a/data/blog-posts.ts
+++ b/data/blog-posts.ts
@@ -1,0 +1,46 @@
+export interface BlogPost {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  date: string; // ISO date
+  readTime: string;
+  category: string;
+  tags: string[];
+}
+
+export const blogPosts: BlogPost[] = [
+  {
+    id: '1',
+    slug: 'best-practices-for-medical-device-test-automation',
+    title: 'Best Practices for Medical Device Test Automation',
+    excerpt:
+      'Exploring effective strategies for implementing automated testing in medical device development while maintaining regulatory compliance.',
+    date: '2024-01-15',
+    readTime: '8 min read',
+    category: 'Automation',
+    tags: ['Medical Devices', 'Test Automation', 'ISO 13485'],
+  },
+  {
+    id: '2',
+    slug: 'requirements-engineering-in-complex-systems',
+    title: 'Requirements Engineering in Complex Systems',
+    excerpt:
+      'A deep dive into how proper requirements engineering can make or break complex system implementations.',
+    date: '2024-01-08',
+    readTime: '6 min read',
+    category: 'Systems Engineering',
+    tags: ['Requirements', 'Systems', 'Engineering'],
+  },
+  {
+    id: '3',
+    slug: 'python-for-engineering-automation',
+    title: 'Python for Engineering Automation',
+    excerpt:
+      'How Python has transformed our approach to engineering automation and the tools that make it possible.',
+    date: '2024-01-01',
+    readTime: '10 min read',
+    category: 'Programming',
+    tags: ['Python', 'Automation', 'Engineering'],
+  },
+];


### PR DESCRIPTION
## Summary
- pull blog posts from new `blog-posts.ts` data source
- show post list instead of "Coming Soon" section
- add placeholder route for individual blog posts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494ec38d908322bb30d45b926b5cae